### PR TITLE
Refactor UI for brutalist consistency and clarity

### DIFF
--- a/model.go
+++ b/model.go
@@ -256,11 +256,19 @@ func (m Model) View() string {
 	case "entries":
 		return ui.RenderEntryList(m.width, m.height, m.entries, m.selectedEntry, m.todos, m.filterTags, m.filterDate, m.markedForDeletion, m.statusMsg)
 	case "view_entry":
-		return ui.RenderEntryView(m.width, m.height, m.viewingEntry, m.todos, m.scrollOffset, m.markedForDeletion, m.statusMsg)
+		// Calculate filtered/sorted entry position for footer display
+		filtered := helpers.FilterEntriesByDateRange(m.entries, m.filterDate)
+		filtered = helpers.FilterEntriesByTags(filtered, m.filterTags)
+		sorted := helpers.SortEntriesForDisplay(filtered)
+		return ui.RenderEntryView(m.width, m.height, m.viewingEntry, m.todos, m.scrollOffset, m.markedForDeletion, m.statusMsg, m.selectedEntry, len(sorted))
 	case "todos":
 		return ui.RenderTodoList(m.width, m.height, m.displayTodos, m.entries, m.selectedTodo, m.filterTags, m.filterDate, m.markedForDeletion, m.statusMsg)
 	case "view_todo":
-		return ui.RenderTodoView(m.width, m.height, m.viewingTodo, m.entries, m.scrollOffset, m.markedForDeletion, m.statusMsg)
+		// Calculate filtered/sorted todo position for footer display
+		filtered := helpers.FilterTodosByDateRange(m.displayTodos, m.filterDate)
+		filtered = helpers.FilterTodosByTags(filtered, m.filterTags)
+		sorted := helpers.SortTodosForDisplay(filtered)
+		return ui.RenderTodoView(m.width, m.height, m.viewingTodo, m.entries, m.scrollOffset, m.markedForDeletion, m.statusMsg, m.selectedTodo, len(sorted))
 	case "unified_filter":
 		return ui.RenderUnifiedFilter(m.width, m.height, m.unifiedFilterInput, m.availableTags, m.autocompleteTag, m.statusMsg)
 	case "add_todo":

--- a/ui/add_todo_form.go
+++ b/ui/add_todo_form.go
@@ -6,5 +6,5 @@ import (
 
 // RenderAddTodoForm renders the standalone todo creation form
 func RenderAddTodoForm(width, height int, ti textarea.Model, statusMsg string, hasUnsaved bool) string {
-	return RenderFormView(width, height, ti.View(), "Add Todo", statusMsg, hasUnsaved, "enter", "save", "esc", "cancel")
+	return RenderFormView(width, height, ti.View(), statusMsg, hasUnsaved, "enter", "save", "esc", "cancel")
 }

--- a/ui/entry_form.go
+++ b/ui/entry_form.go
@@ -6,5 +6,5 @@ import (
 
 // RenderEntryForm renders the entry editing form
 func RenderEntryForm(width, height int, ta textarea.Model, statusMsg string, hasUnsaved bool) string {
-	return RenderFormView(width, height, ta.View(), "New Entry", statusMsg, hasUnsaved, "ctrl+s", "save", "esc", "cancel")
+	return RenderFormView(width, height, ta.View(), statusMsg, hasUnsaved, "ctrl+s", "save", "esc", "cancel")
 }

--- a/ui/entry_list.go
+++ b/ui/entry_list.go
@@ -29,28 +29,17 @@ func RenderEntryList(width, height int, entries []models.Entry, selectedIdx int,
 		// Render visible items
 		for i := start; i < end; i++ {
 			entry := sorted[i]
-			// Table format: date  title (padded)  tags
+			// Table format: date  title
 			timestamp := entry.Timestamp.Format("2006-01-02")
 
-			// Pad title to fixed width for column alignment
-			titleWidth := 30
-			paddedTitle := entry.Title
-			if len(paddedTitle) > titleWidth {
-				paddedTitle = paddedTitle[:titleWidth]
+			// Add + prefix if entry has todos
+			if len(entry.TodoIDs) > 0 {
+				timestamp = "+" + timestamp
 			} else {
-				paddedTitle = paddedTitle + strings.Repeat(" ", titleWidth-len(paddedTitle))
+				timestamp = " " + timestamp
 			}
 
-			line := fmt.Sprintf("%s  %s", timestamp, paddedTitle)
-
-			// Add tags if present (aligned after padded title)
-			if len(entry.Tags) > 0 {
-				tagStr := ""
-				for _, tag := range entry.Tags {
-					tagStr += " @" + tag
-				}
-				line += tagStr
-			}
+			line := fmt.Sprintf("%s  %s", timestamp, entry.Title)
 
 			// Add selection marker and deletion marker
 			var prefix string
@@ -90,27 +79,29 @@ func RenderEntryList(width, height int, entries []models.Entry, selectedIdx int,
 	// Header
 	header := RenderHeader(width, "n", "new", "a", "todo", "j/k", "nav", "enter", "view", "d", "del", "/", "filter", "t", "todos", "q", "quit")
 
-	// Footer
-	footerTitle := "Entries"
+	// Footer (show only filter context, no view label)
+	var footerTitle string
 	if len(filterTags) > 0 {
-		footerTitle += " " + strings.Join(filterTags, " ")
+		footerTitle = strings.Join(filterTags, " ")
 	}
 	if filterDate != "" {
-		footerTitle += " " + filterDate
+		if footerTitle != "" {
+			footerTitle += " "
+		}
+		footerTitle += filterDate
+	}
+	// Wrap filters in brackets if present
+	if footerTitle != "" {
+		footerTitle = "[" + footerTitle + "]"
 	}
 
-	// Build stats with scroll info (statusMsg now in message line, not footer)
+	// Build stats showing selected entry position
 	var stats string
 	if len(sorted) > 0 {
-		start, end := CalculateViewport(len(sorted), selectedIdx, height)
-		if end-start < len(sorted) {
-			stats = fmt.Sprintf("%d-%d of %d items", start+1, end, len(sorted))
-		} else {
-			stats = fmt.Sprintf("%d items", len(sorted))
-		}
+		stats = fmt.Sprintf("Entry %d of %d", selectedIdx+1, len(sorted))
 	}
 
-	footer := RenderFooter(width, footerTitle, stats)
+	footer := RenderFooter(width, stats, footerTitle)
 
 	return AssembleView(header, list, footer, width, height, statusMsg)
 }

--- a/ui/entry_view.go
+++ b/ui/entry_view.go
@@ -10,9 +10,10 @@ import (
 )
 
 // RenderEntryView renders a read-only view of an entry
-func RenderEntryView(width, height int, entry models.Entry, allTodos []models.Todo, scrollOffset int, markedForDeletion map[string]string, statusMsg string) string {
-	// Title at top
-	title := GetNormalItemStyle().Render(entry.Title)
+func RenderEntryView(width, height int, entry models.Entry, allTodos []models.Todo, scrollOffset int, markedForDeletion map[string]string, statusMsg string, currentIndex int, totalCount int) string {
+	// Title at top with date
+	titleText := fmt.Sprintf("%s: %s", entry.Timestamp.Format("2006-01-02"), entry.Title)
+	title := GetNormalItemStyle().Render(titleText)
 
 	// Body
 	bodyStyle := GetNormalItemStyle().
@@ -108,21 +109,12 @@ func RenderEntryView(width, height int, entry models.Entry, allTodos []models.To
 	// Header
 	header := RenderHeader(width, "n", "new", "a", "todo", "j/k", "nav", "d", "del", "e", "entries", "t", "todos", "q", "quit")
 
-	// Footer: date (no time) + tags + marked indicator + scroll info
-	footerTitle := entry.Timestamp.Format("2006-01-02")
+	// Footer: entry position + marked indicator + scroll info
+	footerTitle := fmt.Sprintf("Entry %d of %d", currentIndex+1, totalCount)
 
 	// Add marked indicator if entry is marked for deletion
 	if _, isMarked := markedForDeletion[entry.ID]; isMarked {
 		footerTitle += " [MARKED FOR DELETION]"
-	}
-
-	if len(entry.Tags) > 0 {
-		// Add @ prefix to tags for clarity
-		var tagStrings []string
-		for _, tag := range entry.Tags {
-			tagStrings = append(tagStrings, "@"+tag)
-		}
-		footerTitle += " " + strings.Join(tagStrings, " ")
 	}
 
 	// Footer stats (statusMsg now in message line, not footer)

--- a/ui/styles.go
+++ b/ui/styles.go
@@ -157,20 +157,13 @@ func AssembleView(header, content, footer string, width, height int, statusMsg s
 	return result
 }
 
-// RenderFormView renders a form with header, input, footer, and message line
-func RenderFormView(width, height int, inputView, footerTitle, statusMsg string, hasUnsaved bool, headerKeys ...string) string {
+// RenderFormView renders a form with header, input, and message line
+func RenderFormView(width, height int, inputView, statusMsg string, hasUnsaved bool, headerKeys ...string) string {
 	// Build header with provided keys
 	header := RenderHeader(width, headerKeys...)
 
-	// Build footer with unsaved indicator (no statusMsg in footer anymore)
-	footerStatus := ""
-	if hasUnsaved {
-		footerStatus = "[Unsaved]"
-	}
-	footer := RenderFooter(width, footerTitle, footerStatus)
-
 	// Calculate padding for content area
-	contentHeight := height - 3 // header + footer + message line
+	contentHeight := height - 2 // header + message line (no footer in forms)
 	inputLines := lipgloss.Height(inputView)
 	padding := contentHeight - inputLines
 	if padding < 0 {
@@ -180,12 +173,12 @@ func RenderFormView(width, height int, inputView, footerTitle, statusMsg string,
 	// Build message line (neomutt-style)
 	messageLine := RenderMessageLine(width, statusMsg)
 
-	// Build full view
+	// Build full view (no footer)
 	result := header + "\n" + inputView
 	if padding > 0 {
 		result += strings.Repeat("\n", padding)
 	}
-	result += "\n" + footer + "\n" + messageLine
+	result += "\n" + messageLine
 
 	return result
 }
@@ -273,11 +266,14 @@ func RenderHeader(width int, keyDescPairs ...string) string {
 }
 
 // RenderFooter renders the bottom bar with view context and stats
-// Format: "Entries @work  15 items"
+// Format: "Entries @work  15 items" or "15 items" (no leading space when title is empty)
 func RenderFooter(width int, title string, stats string) string {
 	content := title
 	if stats != "" {
-		content += "  " + stats
+		if title != "" {
+			content += "  "
+		}
+		content += stats
 	}
 
 	// Truncate if too long

--- a/ui/todo_list.go
+++ b/ui/todo_list.go
@@ -41,19 +41,10 @@ func RenderTodoList(width, height int, todos []models.Todo, entries []models.Ent
 				checkbox = "[x]" // done
 			}
 
-			// Table format: checkbox  date  title (padded)  tags
+			// Table format: checkbox  date  title  tags
 			dateStr := todo.CreatedAt.Format("2006-01-02")
 
-			// Pad title to fixed width for column alignment
-			titleWidth := 35
-			paddedTitle := todo.Title
-			if len(paddedTitle) > titleWidth {
-				paddedTitle = paddedTitle[:titleWidth]
-			} else {
-				paddedTitle = paddedTitle + strings.Repeat(" ", titleWidth-len(paddedTitle))
-			}
-
-			line := fmt.Sprintf("%s %s  %s", checkbox, dateStr, paddedTitle)
+			line := fmt.Sprintf("%s %s  %s", checkbox, dateStr, todo.Title)
 
 			// Add selection marker and deletion marker
 			var prefix string
@@ -103,42 +94,29 @@ func RenderTodoList(width, height int, todos []models.Todo, entries []models.Ent
 	// Header
 	header := RenderHeader(width, "n", "new", "a", "todo", "enter", "view", "j/k", "nav", "space", "cycle", "d", "del", "/", "filter", "e", "entries", "q", "quit")
 
-	// Footer
-	footerTitle := "Todos"
+	// Footer (show only filter context, no view label)
+	var footerTitle string
 	if len(filterTags) > 0 {
-		footerTitle += " " + strings.Join(filterTags, " ")
+		footerTitle = strings.Join(filterTags, " ")
 	}
 	if filterDate != "" {
-		footerTitle += " " + filterDate
-	}
-
-	// Stats for footer
-	openCount := 0
-	nextCount := 0
-	doneCount := 0
-	for _, todo := range filtered {
-		switch todo.Status {
-		case "open":
-			openCount++
-		case "next":
-			nextCount++
-		case "done":
-			doneCount++
+		if footerTitle != "" {
+			footerTitle += " "
 		}
+		footerTitle += filterDate
+	}
+	// Wrap filters in brackets if present
+	if footerTitle != "" {
+		footerTitle = "[" + footerTitle + "]"
 	}
 
-	// Build stats with scroll info (statusMsg now in message line, not footer)
+	// Build stats showing selected todo position
 	var stats string
 	if len(filtered) > 0 {
-		start, end := CalculateViewport(len(filtered), selectedIdx, height)
-		if end-start < len(filtered) {
-			stats = fmt.Sprintf("%d-%d of %d | %d open, %d next, %d done", start+1, end, len(filtered), openCount, nextCount, doneCount)
-		} else {
-			stats = fmt.Sprintf("%d open, %d next, %d done", openCount, nextCount, doneCount)
-		}
+		stats = fmt.Sprintf("Todo %d of %d", selectedIdx+1, len(filtered))
 	}
 
-	footer := RenderFooter(width, footerTitle, stats)
+	footer := RenderFooter(width, stats, footerTitle)
 
 	return AssembleView(header, list, footer, width, height, statusMsg)
 }

--- a/ui/todo_view.go
+++ b/ui/todo_view.go
@@ -32,7 +32,16 @@ func highlightTodoInText(body, todoTitle string) string {
 }
 
 // RenderTodoView renders a read-only view of a todo
-func RenderTodoView(width, height int, todo models.Todo, allEntries []models.Entry, scrollOffset int, markedForDeletion map[string]string, statusMsg string) string {
+func RenderTodoView(width, height int, todo models.Todo, allEntries []models.Entry, scrollOffset int, markedForDeletion map[string]string, statusMsg string, currentIndex int, totalCount int) string {
+	// Status and date at top
+	statusIcon := "[ ]" // open
+	if todo.Status == "next" {
+		statusIcon = "[>]"
+	} else if todo.Status == "done" {
+		statusIcon = "[x]"
+	}
+	statusLine := fmt.Sprintf("%s %s", statusIcon, todo.CreatedAt.Format("2006-01-02"))
+
 	// Todo title (wrappable)
 	titleStyle := GetNormalItemStyle().
 		Width(width - 8)
@@ -136,15 +145,8 @@ func RenderTodoView(width, height int, todo models.Todo, allEntries []models.Ent
 	// Header
 	header := RenderHeader(width, "n", "new", "a", "todo", "space", "cycle", "j/k", "nav", "d", "del", "e", "entries", "t", "todos", "q", "quit")
 
-	// Footer: status indicator + date + tags + scroll info
-	statusIcon := "[ ]" // open
-	if todo.Status == "next" {
-		statusIcon = "[>]"
-	} else if todo.Status == "done" {
-		statusIcon = "[x]"
-	}
-
-	footerTitle := fmt.Sprintf("%s %s", statusIcon, todo.CreatedAt.Format("2006-01-02"))
+	// Footer: position + marked indicator + scroll info
+	footerTitle := fmt.Sprintf("Todo %d of %d", currentIndex+1, totalCount)
 
 	// Add marked indicator if todo is marked for deletion
 	if _, isMarked := markedForDeletion[todo.ID]; isMarked {
@@ -159,8 +161,8 @@ func RenderTodoView(width, height int, todo models.Todo, allEntries []models.Ent
 
 	footer := RenderFooter(width, footerTitle, footerStats)
 
-	// Build main content
-	mainContent := renderedTitle + linkedSection
+	// Build main content (status + date at top, then blank line, then title)
+	mainContent := statusLine + "\n\n" + renderedTitle + linkedSection
 
 	// Calculate padding
 	contentHeight := height - 3 // header + footer + message line

--- a/update_todos.go
+++ b/update_todos.go
@@ -166,18 +166,19 @@ func (m Model) handleTodosListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			switch todo.Status {
 			case "open":
 				todo.Status = "next"
-				m.statusMsg = "→ Next"
+				m.statusMsg = "Todo marked as next"
 			case "next":
 				todo.Status = "done"
-				m.statusMsg = "✓ Done"
+				m.statusMsg = "Todo marked as done"
 			case "done":
 				todo.Status = "open"
-				m.statusMsg = "○ Open"
+				m.statusMsg = "Todo marked as open"
 			default:
 				// Unknown status, set to open
 				todo.Status = "open"
-				m.statusMsg = "○ Open"
+				m.statusMsg = "Todo marked as open"
 			}
+			m.statusTime = time.Now()
 
 			// Update in m.todos array and displayTodos (find by ID)
 			// We can't update displayTodos[m.selectedTodo] directly because

--- a/update_view_todo.go
+++ b/update_view_todo.go
@@ -69,18 +69,19 @@ func (m Model) handleViewTodoKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		switch m.viewingTodo.Status {
 		case "open":
 			m.viewingTodo.Status = "next"
-			m.statusMsg = "→ Next"
+			m.statusMsg = "Todo marked as next"
 		case "next":
 			m.viewingTodo.Status = "done"
-			m.statusMsg = "✓ Done"
+			m.statusMsg = "Todo marked as done"
 		case "done":
 			m.viewingTodo.Status = "open"
-			m.statusMsg = "○ Open"
+			m.statusMsg = "Todo marked as open"
 		default:
 			// Unknown status, set to open
 			m.viewingTodo.Status = "open"
-			m.statusMsg = "○ Open"
+			m.statusMsg = "Todo marked as open"
 		}
+		m.statusTime = time.Now()
 
 		// Update in m.todos array and displayTodos (find by ID)
 		for i := range m.todos {


### PR DESCRIPTION
Major UI improvements focused on brutalist design principles:

Views:
- Remove width constraints on entry/todo titles (expand to full width)
- Remove tags from entry list and entry view footers
- Move date from footer to title in entry/todo views
- Add position counters to all list/view footers (Entry/Todo X of Y)
- Remove footer entirely from forms (entry form, add todo form)
- Restructure todo view: status/date at top, position in footer

Footers:
- Remove redundant view labels ("Entries", "Todos", "New Entry", etc.)
- Swap position and filter display (position left, filters right)
- Add brackets around filters for clarity
- Remove status counts from todo list (unnecessary breakdown)
- Fix footer spacing when title is empty

Status messages:
- Change todo status messages to text-based ("Todo marked as done")
- Fix status message timing (add m.statusTime updates in todo cycling)
- Remove [Unsaved] indicator from forms (redundant with confirmations)

Entry list:
- Add + prefix for entries that have todos (simple indicator)

This commit removes 118 lines while adding 87, focusing on clarity over decoration.