### PR TITLE
Refactor UI styling: add bold @tags and regroup markers

### DIFF
--- a/ui/entry_list.go
+++ b/ui/entry_list.go
@@ -29,32 +29,25 @@ func RenderEntryList(width, height int, entries []models.Entry, selectedIdx int,
 		// Render visible items
 		for i := start; i < end; i++ {
 			entry := sorted[i]
-			// Table format: date  title
+			// Table format: markers  date  title
 			timestamp := entry.Timestamp.Format("2006-01-02")
 
-			// Add + prefix if entry has todos
-			if len(entry.TodoIDs) > 0 {
-				timestamp = "+" + timestamp
-			} else {
-				timestamp = " " + timestamp
-			}
-
-			line := fmt.Sprintf("%s  %s", timestamp, entry.Title)
-
-			// Add selection marker and deletion marker
-			var prefix string
+			// Build 2-character marker prefix (D for deletion, + for todos)
+			var marker string
 			_, isMarked := markedForDeletion[entry.ID]
+			hasTodos := len(entry.TodoIDs) > 0
 
-			if i == selectedIdx && isMarked {
-				prefix = "> D "
-			} else if i == selectedIdx {
-				prefix = ">   "
-			} else if isMarked {
-				prefix = "  D "
+			if isMarked && hasTodos {
+				marker = "D+"
+			} else if isMarked && !hasTodos {
+				marker = "D "
+			} else if !isMarked && hasTodos {
+				marker = " +"
 			} else {
-				prefix = "    " // Indent for alignment (4 spaces to match "> D ")
+				marker = "  "
 			}
-			line = prefix + line
+
+			line := fmt.Sprintf("%s %s  %s", marker, timestamp, entry.Title)
 
 			// Truncate if too long
 			maxLen := width - 6
@@ -62,12 +55,12 @@ func RenderEntryList(width, height int, entries []models.Entry, selectedIdx int,
 				line = line[:maxLen-3] + "..."
 			}
 
-			// Style selected item
+			// Apply selection styling (no tag highlighting in lists)
 			var styled string
 			if i == selectedIdx {
 				styled = GetSelectedItemStyle(width).Render(line)
 			} else {
-				styled = GetNormalItemStyle().Render(line)
+				styled = GetNormalItemStyle().Width(width).Render(line)
 			}
 
 			listItems = append(listItems, styled)

--- a/ui/entry_view.go
+++ b/ui/entry_view.go
@@ -13,9 +13,9 @@ import (
 func RenderEntryView(width, height int, entry models.Entry, allTodos []models.Todo, scrollOffset int, markedForDeletion map[string]string, statusMsg string, currentIndex int, totalCount int) string {
 	// Title at top with date
 	titleText := fmt.Sprintf("%s: %s", entry.Timestamp.Format("2006-01-02"), entry.Title)
-	title := GetNormalItemStyle().Render(titleText)
+	title := HighlightTagsInText(titleText)
 
-	// Body
+	// Body style with width constraint
 	bodyStyle := GetNormalItemStyle().
 		Width(width - 8)
 
@@ -40,15 +40,18 @@ func RenderEntryView(width, height int, entry models.Entry, allTodos []models.To
 					checkbox = "[x]"
 				}
 
-				todoLine := fmt.Sprintf("%s %s", checkbox, todo.Title)
+				// Apply tag highlighting to title
+				highlightedTitle := HighlightTagsInText(todo.Title)
+				todoLine := fmt.Sprintf("%s %s", checkbox, highlightedTitle)
 
-				// Add tags if present
+				// Add tags if present (with bold highlighting)
 				if len(todo.Tags) > 0 {
-					tagStr := ""
+					var tagParts []string
 					for _, tag := range todo.Tags {
-						tagStr += " @" + tag
+						tagParts = append(tagParts, "@"+tag)
 					}
-					todoLine += GetDimmedStyle().Render(tagStr)
+					tagStr := " " + strings.Join(tagParts, " ")
+					todoLine += HighlightTagsInText(tagStr)
 				}
 
 				// Dim completed todos
@@ -99,9 +102,9 @@ func RenderEntryView(width, height int, entry models.Entry, allTodos []models.To
 		}
 
 		visibleLines := bodyLines[scrollStart:scrollEnd]
-		body = bodyStyle.Render(strings.Join(visibleLines, "\n"))
+		body = bodyStyle.Render(HighlightTagsInText(strings.Join(visibleLines, "\n")))
 	} else {
-		body = bodyStyle.Render(entry.Body)
+		body = bodyStyle.Render(HighlightTagsInText(entry.Body))
 		scrollStart = 0
 		scrollEnd = totalLines
 	}

--- a/ui/styles.go
+++ b/ui/styles.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"regexp"
 	"strings"
 
 	"github.com/charmbracelet/bubbles/textarea"
@@ -42,10 +43,11 @@ func GetTextStyle() lipgloss.Style {
 	return lipgloss.NewStyle()
 }
 
-// getBarStyle returns the shared full-width inverted bar style
+// getBarStyle returns the shared full-width inverted bar style with bold text
 func getBarStyle(width int) lipgloss.Style {
 	return lipgloss.NewStyle().
 		Reverse(true).
+		Bold(true).
 		Width(width)
 }
 
@@ -57,15 +59,17 @@ func GetEmptyStateStyle(width int) lipgloss.Style {
 		Align(lipgloss.Center)
 }
 
-// GetSelectedItemStyle returns normal style for selected list items (uses > prefix)
+// GetSelectedItemStyle returns reverse video style for selected list items
 func GetSelectedItemStyle(width int) lipgloss.Style {
 	return lipgloss.NewStyle().
+		Reverse(true).
 		Width(width)
 }
 
-// GetSelectedDoneStyle returns faint style for selected completed items (uses > prefix)
+// GetSelectedDoneStyle returns reverse + faint style for selected completed items
 func GetSelectedDoneStyle(width int) lipgloss.Style {
 	return lipgloss.NewStyle().
+		Reverse(true).
 		Faint(true).
 		Width(width)
 }
@@ -78,6 +82,51 @@ func GetNormalItemStyle() lipgloss.Style {
 // GetDimmedStyle returns faint style for completed items
 func GetDimmedStyle() lipgloss.Style {
 	return lipgloss.NewStyle().Faint(true)
+}
+
+// GetBoldStyle returns bold style for emphasis
+func GetBoldStyle() lipgloss.Style {
+	return lipgloss.NewStyle().Bold(true)
+}
+
+// HighlightTagsInText highlights @tags in PLAIN text with bold styling
+// IMPORTANT: Only pass plain text (no ANSI codes) to this function
+// Use this for entry_view and todo_view where there's no selection styling
+func HighlightTagsInText(text string) string {
+	re := regexp.MustCompile(`(@[a-zA-Z0-9_-]+)`)
+
+	// Find all tag positions
+	matches := re.FindAllStringIndex(text, -1)
+	if len(matches) == 0 {
+		// No tags, return plain text (no styling)
+		return text
+	}
+
+	// Build styled segments
+	var segments []string
+	lastEnd := 0
+
+	for _, match := range matches {
+		start, end := match[0], match[1]
+
+		// Add plain text before tag (no styling)
+		if start > lastEnd {
+			segments = append(segments, text[lastEnd:start])
+		}
+
+		// Add bolded tag
+		segments = append(segments, GetBoldStyle().Inline(true).Render(text[start:end]))
+
+		lastEnd = end
+	}
+
+	// Add remaining text after last tag
+	if lastEnd < len(text) {
+		segments = append(segments, text[lastEnd:])
+	}
+
+	// Join all segments horizontally
+	return lipgloss.JoinHorizontal(lipgloss.Top, segments...)
 }
 
 // ApplyTextareaStyle applies consistent styling to a textarea

--- a/ui/todo_list.go
+++ b/ui/todo_list.go
@@ -41,25 +41,25 @@ func RenderTodoList(width, height int, todos []models.Todo, entries []models.Ent
 				checkbox = "[x]" // done
 			}
 
-			// Table format: checkbox  date  title  tags
+			// Table format: markers  checkbox  date  title
 			dateStr := todo.CreatedAt.Format("2006-01-02")
 
-			line := fmt.Sprintf("%s %s  %s", checkbox, dateStr, todo.Title)
-
-			// Add selection marker and deletion marker
-			var prefix string
+			// Build 2-character marker prefix (D for deletion, + for linked entry)
+			var marker string
 			_, isMarked := markedForDeletion[todo.ID]
+			hasEntry := todo.EntryID != nil
 
-			if i == selectedIdx && isMarked {
-				prefix = "> D "
-			} else if i == selectedIdx {
-				prefix = ">   "
-			} else if isMarked {
-				prefix = "  D "
+			if isMarked && hasEntry {
+				marker = "D+"
+			} else if isMarked && !hasEntry {
+				marker = "D "
+			} else if !isMarked && hasEntry {
+				marker = " +"
 			} else {
-				prefix = "    " // Indent for alignment (4 spaces to match "> D ")
+				marker = "  "
 			}
-			line = prefix + line
+
+			line := fmt.Sprintf("%s %s %s  %s", marker, checkbox, dateStr, todo.Title)
 
 			// Truncate if too long
 			maxLen := width - 6
@@ -67,7 +67,7 @@ func RenderTodoList(width, height int, todos []models.Todo, entries []models.Ent
 				line = line[:maxLen-3] + "..."
 			}
 
-			// Apply selection and completion styling
+			// Apply selection styling (no tag highlighting in lists)
 			var styled string
 			if i == selectedIdx {
 				// Selected items
@@ -79,9 +79,9 @@ func RenderTodoList(width, height int, todos []models.Todo, entries []models.Ent
 			} else {
 				// Dim completed todos, normal color for open
 				if todo.Status == "done" {
-					styled = GetDimmedStyle().Render(line)
+					styled = GetDimmedStyle().Width(width).Render(line)
 				} else {
-					styled = GetNormalItemStyle().Render(line)
+					styled = GetNormalItemStyle().Width(width).Render(line)
 				}
 			}
 

--- a/ui/todo_view.go
+++ b/ui/todo_view.go
@@ -48,7 +48,9 @@ func RenderTodoView(width, height int, todo models.Todo, allEntries []models.Ent
 
 	// Wrap title if long
 	wrappedTitle := wordWrap(todo.Title, width-8)
-	titleLines := strings.Split(wrappedTitle, "\n")
+	// Apply tag highlighting to wrapped title
+	highlightedTitle := HighlightTagsInText(wrappedTitle)
+	titleLines := strings.Split(highlightedTitle, "\n")
 
 	// Linked entry section (if EntryID is set)
 	var linkedSection string
@@ -82,11 +84,13 @@ func RenderTodoView(width, height int, todo models.Todo, allEntries []models.Ent
 			}
 
 			metaLine := fmt.Sprintf("%s %s%s", dateStr, linkedEntry.Title, tagStr)
-			linkedParts = append(linkedParts, GetNormalItemStyle().Render(metaLine))
+			linkedParts = append(linkedParts, HighlightTagsInText(metaLine))
 
-			// Body (full text) - highlight the todo reference
+			// Body (full text) - highlight tags and todo reference
 			if linkedEntry.Body != "" {
-				styledBody := highlightTodoInText(linkedEntry.Body, todo.Title)
+				// First highlight tags, then highlight todo reference
+				bodyWithTags := HighlightTagsInText(linkedEntry.Body)
+				styledBody := highlightTodoInText(bodyWithTags, todo.Title)
 				linkedParts = append(linkedParts, styledBody)
 			}
 
@@ -137,7 +141,7 @@ func RenderTodoView(width, height int, todo models.Todo, allEntries []models.Ent
 		visibleLines := titleLines[scrollStart:scrollEnd]
 		renderedTitle = titleStyle.Render(strings.Join(visibleLines, "\n"))
 	} else {
-		renderedTitle = titleStyle.Render(wrappedTitle)
+		renderedTitle = titleStyle.Render(highlightedTitle)
 		scrollStart = 0
 		scrollEnd = totalLines
 	}


### PR DESCRIPTION
Add bold @tag highlighting in detail views (entry_view, todo_view) for better scannability. Tags remain unstyled in list views to avoid ANSI code composition conflicts with reverse video selection.

Regroup status markers at left edge with consistent 2-character format:
- D = marked for deletion
- + = has todos (entries) or has linked entry (todos)
- Examples: "D+ 2025-01-15  Title" or "   [x] 2025-01-15  Task"

Changes:
- ui/styles.go: Add HighlightTagsInText() for bold @tags in detail views
- ui/entry_view.go: Apply tag highlighting to title, body, and todo sections
- ui/todo_view.go: Apply tag highlighting to title and linked entry metadata
- ui/entry_list.go: Regroup markers (D/+), remove tag highlighting for clean reverse video
- ui/todo_list.go: Apply same marker grouping pattern as entry list