### PR TITLE
Fix indentation issues and simplify styling

### DIFF
--- a/ui/entry_view.go
+++ b/ui/entry_view.go
@@ -15,10 +15,6 @@ func RenderEntryView(width, height int, entry models.Entry, allTodos []models.To
 	titleText := fmt.Sprintf("%s: %s", entry.Timestamp.Format("2006-01-02"), entry.Title)
 	title := HighlightTagsInText(titleText)
 
-	// Body style with width constraint
-	bodyStyle := GetNormalItemStyle().
-		Width(width - 8)
-
 	// Todos section (if any)
 	var todosSection string
 	var todoLineCount int
@@ -102,9 +98,9 @@ func RenderEntryView(width, height int, entry models.Entry, allTodos []models.To
 		}
 
 		visibleLines := bodyLines[scrollStart:scrollEnd]
-		body = bodyStyle.Render(HighlightTagsInText(strings.Join(visibleLines, "\n")))
+		body = HighlightTagsInText(strings.Join(visibleLines, "\n"))
 	} else {
-		body = bodyStyle.Render(HighlightTagsInText(entry.Body))
+		body = HighlightTagsInText(entry.Body)
 		scrollStart = 0
 		scrollEnd = totalLines
 	}

--- a/ui/styles.go
+++ b/ui/styles.go
@@ -1,7 +1,6 @@
 package ui
 
 import (
-	"regexp"
 	"strings"
 
 	"github.com/charmbracelet/bubbles/textarea"
@@ -66,11 +65,10 @@ func GetSelectedItemStyle(width int) lipgloss.Style {
 		Width(width)
 }
 
-// GetSelectedDoneStyle returns reverse + faint style for selected completed items
+// GetSelectedDoneStyle returns reverse style for selected completed items
 func GetSelectedDoneStyle(width int) lipgloss.Style {
 	return lipgloss.NewStyle().
 		Reverse(true).
-		Faint(true).
 		Width(width)
 }
 
@@ -89,44 +87,10 @@ func GetBoldStyle() lipgloss.Style {
 	return lipgloss.NewStyle().Bold(true)
 }
 
-// HighlightTagsInText highlights @tags in PLAIN text with bold styling
-// IMPORTANT: Only pass plain text (no ANSI codes) to this function
-// Use this for entry_view and todo_view where there's no selection styling
+// HighlightTagsInText returns text as-is (tag highlighting removed)
+// Previously applied bold to @tags but didn't add useful value
 func HighlightTagsInText(text string) string {
-	re := regexp.MustCompile(`(@[a-zA-Z0-9_-]+)`)
-
-	// Find all tag positions
-	matches := re.FindAllStringIndex(text, -1)
-	if len(matches) == 0 {
-		// No tags, return plain text (no styling)
-		return text
-	}
-
-	// Build styled segments
-	var segments []string
-	lastEnd := 0
-
-	for _, match := range matches {
-		start, end := match[0], match[1]
-
-		// Add plain text before tag (no styling)
-		if start > lastEnd {
-			segments = append(segments, text[lastEnd:start])
-		}
-
-		// Add bolded tag
-		segments = append(segments, GetBoldStyle().Inline(true).Render(text[start:end]))
-
-		lastEnd = end
-	}
-
-	// Add remaining text after last tag
-	if lastEnd < len(text) {
-		segments = append(segments, text[lastEnd:])
-	}
-
-	// Join all segments horizontally
-	return lipgloss.JoinHorizontal(lipgloss.Top, segments...)
+	return text
 }
 
 // ApplyTextareaStyle applies consistent styling to a textarea

--- a/ui/todo_view.go
+++ b/ui/todo_view.go
@@ -7,28 +7,10 @@ import (
 	"github.com/apodacaa/amos/internal/models"
 )
 
-// highlightTodoInText highlights the todo title in the entry body
+// highlightTodoInText returns the body text as-is
+// Previously tried to highlight the todo, but rendering caused indentation issues
 func highlightTodoInText(body, todoTitle string) string {
-	// Find "!todo [title]" pattern
-	todoPattern := "!todo " + todoTitle
-
-	// Split by the todo, highlight the todo part
-	parts := strings.Split(body, todoPattern)
-	if len(parts) <= 1 {
-		// Not found, return as-is in normal style
-		return GetNormalItemStyle().Render(body)
-	}
-
-	// Build styled string: body text + highlighted todo
-	var result strings.Builder
-	for i, part := range parts {
-		result.WriteString(GetNormalItemStyle().Render(part))
-		if i < len(parts)-1 {
-			// Add highlighted todo between parts
-			result.WriteString(GetNormalItemStyle().Render(todoPattern))
-		}
-	}
-	return result.String()
+	return body
 }
 
 // RenderTodoView renders a read-only view of a todo


### PR DESCRIPTION
Remove width constraints and tag highlighting that caused indentation artifacts on !todo lines in entry and todo views.

Changes:
- ui/entry_view.go: Remove bodyStyle Width() constraint that caused wrapping issues
- ui/todo_view.go: Simplify highlightTodoInText to return text as-is
- ui/styles.go: Remove GetSelectedDoneStyle faint (conflicts with reverse), simplify HighlightTagsInText to skip tag styling entirely

Result: Clean text rendering without indentation artifacts or unnecessary styling complexity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)