### PR TITLE
Fix line wrapping in entry and todo views

### DIFF
--- a/ui/entry_view.go
+++ b/ui/entry_view.go
@@ -72,8 +72,11 @@ func RenderEntryView(width, height int, entry models.Entry, allTodos []models.To
 		availableHeight = 5
 	}
 
-	// Split body into lines
-	bodyLines := strings.Split(entry.Body, "\n")
+	// Wrap body text to fit width, preserving original line breaks
+	wrappedBody := wrapBodyText(entry.Body, width-8)
+
+	// Split wrapped body into lines
+	bodyLines := strings.Split(wrappedBody, "\n")
 	totalLines := len(bodyLines)
 
 	// Apply scroll offset
@@ -100,7 +103,7 @@ func RenderEntryView(width, height int, entry models.Entry, allTodos []models.To
 		visibleLines := bodyLines[scrollStart:scrollEnd]
 		body = HighlightTagsInText(strings.Join(visibleLines, "\n"))
 	} else {
-		body = HighlightTagsInText(entry.Body)
+		body = HighlightTagsInText(wrappedBody)
 		scrollStart = 0
 		scrollEnd = totalLines
 	}

--- a/ui/todo_view.go
+++ b/ui/todo_view.go
@@ -68,10 +68,12 @@ func RenderTodoView(width, height int, todo models.Todo, allEntries []models.Ent
 			metaLine := fmt.Sprintf("%s %s%s", dateStr, linkedEntry.Title, tagStr)
 			linkedParts = append(linkedParts, HighlightTagsInText(metaLine))
 
-			// Body (full text) - highlight tags and todo reference
+			// Body (full text) - wrap, highlight tags and todo reference
 			if linkedEntry.Body != "" {
+				// Wrap body text to fit width
+				wrappedBody := wrapBodyText(linkedEntry.Body, width-8)
 				// First highlight tags, then highlight todo reference
-				bodyWithTags := HighlightTagsInText(linkedEntry.Body)
+				bodyWithTags := HighlightTagsInText(wrappedBody)
 				styledBody := highlightTodoInText(bodyWithTags, todo.Title)
 				linkedParts = append(linkedParts, styledBody)
 			}
@@ -169,6 +171,29 @@ func RenderTodoView(width, height int, todo models.Todo, allEntries []models.Ent
 	content += "\n" + footer + "\n" + messageLine
 
 	return content
+}
+
+// wrapBodyText wraps body text while preserving original line breaks
+func wrapBodyText(text string, width int) string {
+	if width <= 0 {
+		return text
+	}
+
+	lines := strings.Split(text, "\n")
+	var wrappedLines []string
+
+	for _, line := range lines {
+		if line == "" {
+			// Preserve blank lines
+			wrappedLines = append(wrappedLines, "")
+		} else {
+			// Wrap long lines
+			wrapped := wordWrap(line, width)
+			wrappedLines = append(wrappedLines, wrapped)
+		}
+	}
+
+	return strings.Join(wrappedLines, "\n")
 }
 
 // wordWrap wraps text to fit within a given width


### PR DESCRIPTION
Body text in entry view and linked entry text in todo view were going off-screen after removing width constraints to fix indentation issues.

Solution:
- Added wrapBodyText() helper to wrap text while preserving line breaks
- Applied wrapping at width-8 to match current padding
- Reuses existing wordWrap() function for per-line wrapping

🤖 Generated with [Claude Code](https://claude.com/claude-code)