### PR TITLE
Preserve !todo lines in entry text and sync via text-matching

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,7 +76,7 @@ This codebase is small (~3000 lines) and well-organized. Work efficiently:
 - Entry list: `update_entries.go`, `ui/entry_list.go`
 - Entry view: `update_entry_view.go`, `ui/entry_view.go` (press `i` to edit)
 - External editor: `internal/helpers/editor.go` (GetEditor, CreateTempFile, ParseEntryFile)
-- Edit workflow: Press `n` to create or `i` from entry view to edit → launches $EDITOR → on save/exit, extracts todos and returns to TUI
+- Edit workflow: Press `n` to create or `i` from entry view to edit → launches $EDITOR → on save/exit, syncs todos via text-matching and returns to TUI
 
 **Todo Management:**
 - Todo list: `update_todos.go`, `ui/todo_list.go`
@@ -162,13 +162,13 @@ internal/
     todo.go              # Todo{ID, Title, Status, Tags, CreatedAt, EntryID, Position}
   storage/               # JSON persistence (configurable directory)
     storage.go           # Load/Save functions, directory initialization
-    system_config.go     # SystemConfig{DataDir, Theme, HideCompletedTodos} (~/.config/amos/settings.json)
+    system_config.go     # SystemConfig{DataDir, Theme} (~/.config/amos/settings.json)
   helpers/               # Reusable business logic
     sorting.go           # Centralized sorting (todos by status→position→date)
     tags.go              # Tag extraction (@mention syntax) and filtering
-    todos.go             # Todo extraction (!todo syntax)
+    todos.go             # Todo extraction (!todo syntax), SyncEntryTodos (text-match lifecycle)
     dates.go             # Date filter parsing and date range filtering
-    filter.go            # Centralized filtering (ApplyEntryFilters, ApplyTodoFilters, FilterTodosByVisibility)
+    filter.go            # Centralized filtering (ApplyEntryFilters, ApplyTodoFilters)
     filter_parser.go     # Unified filter parsing (tags + dates)
     editor.go            # External editor support ($EDITOR, temp files, parsing)
 ```
@@ -194,7 +194,7 @@ internal/
 **Data Persistence**:
 - JSON files in data directory (default: `~/.amos/`)
 - Customizable via `AMOS_DATA_DIR` env var or `~/.config/amos/settings.json`
-- All config: `~/.config/amos/settings.json` (stores data directory path, theme, and hide_completed_todos preference)
+- All config: `~/.config/amos/settings.json` (stores data directory path and theme)
 - User data files: `entries.json`, `todos.json` (in configured data directory)
 - `storage.LoadEntries()` / `storage.SaveEntry()` for entries
 - `storage.LoadTodos()` / `storage.SaveTodo()` for todos
@@ -210,7 +210,7 @@ internal/
 - **No Entry.TodoIDs field** - unidirectional relationship via Todo.EntryID only
 - Position field enables manual priority (lower = higher)
 - Sorting: open todos first → by position → newest first (helpers/sorting.go)
-- Extract from entries with `!todo Task description @tag` syntax
+- Synced from entries via text-matching: `!todo Task description @tag` syntax in entry body
 
 **Unified Filter System (Tags + Dates)**:
 - Auto-extracted tags from `@mention` syntax in entry body and todo titles
@@ -300,7 +300,7 @@ The app follows strict brutalist principles:
 - `launchEditor()` in commands.go creates temp file and launches editor via `tea.ExecProcess`
 - `editorFinishedMsg` handler in model.go parses result and saves entry
 - Template comments (<!-- ... -->) are stripped from parsed content
-- `!todo` lines are extracted as linked todos on save
+- `!todo` lines remain in entry text; todos are synced via text-matching on save
 
 **Textarea (todos and filters)**:
 - Todo form: single-line textarea with height=1 (model.go:37-39)
@@ -367,12 +367,12 @@ Todos stored in `<data-dir>/todos.json` (default: `~/.amos/todos.json`):
   - Entry editing: Uses external $EDITOR (vim, nano, etc.) following Unix conventions (like aerc, mutt, git)
     - Press `n` from any list view to create new entry → opens editor with template
     - Press `i` from entry view to edit → opens editor with existing content
-    - On save/exit: extracts `!todo` lines as linked todos, removes markup, saves entry
+    - On save/exit: syncs `!todo` lines via text-matching (dedup, orphan removed), saves entry with `!todo` lines intact
     - Empty file (or only template comments) cancels the operation
     - Editor preference: $EDITOR → $VISUAL → nano (fallback)
   - Todo editing: Open todo view, press `i` to edit, save with `Enter`, esc returns to todo view
   - Timestamp updates: Editing an entry updates its timestamp to now (moves to top of list)
-  - Todo extraction: `!todo Task @tag` lines in editor become linked todos on save. Todos become independent entities edited via todo view.
+  - Todo sync: `!todo Task @tag` lines in editor are synced via text-matching on save (dedup existing, orphan removed). `!todo` lines remain in entry text. Todos become independent entities edited via todo view.
 - **Deletion**: neomutt-style multi-select pattern
   - `d` key marks/unmarks items for deletion (shows "D" prefix in lists, footer text in entry view)
   - After marking items, status message shows "X items marked. Press $ to delete"
@@ -386,9 +386,8 @@ Todos stored in `<data-dir>/todos.json` (default: `~/.amos/todos.json`):
 - **Page navigation**: `f/b` keys in entry/todo/help views for page forward/backward (no line scrolling)
 - **Help page**: Press `?` from any read-only view to see comprehensive documentation
 - Todo status: "open", "next", or "done" (direct keys: `o`=open, `p`=next/priority, `x`=done)
-- **Toggle completed todos**: `z` key in todo list hides/shows done todos. Preference persists in config. Done todos always visible in entry view (preserves journal history).
 - Tag syntax: `@tagname` in entry body or todo title auto-extracts to Tags array
-- Todo syntax: `!todo Task description @tag` creates linked todo with extracted tags when exiting entry form (ESC). The `!todo` line is automatically removed from entry text on exit. During editing, `!todo` markup stays visible until ESC. To edit todos, use the dedicated todo view (press `i` from todo list).
+- Todo syntax: `!todo Task description @tag` creates linked todo with extracted tags on save. `!todo` lines remain in entry text permanently. Editing a `!todo` line orphans the old todo and creates a new one. Deleting a `!todo` line orphans the todo (it remains in the todo list as standalone). To edit todos, use the dedicated todo view (press `i` from todo list).
 - Unified filtering: Works identically for both entries and todos views
   - `/` key opens filter with current values for editing
   - After applying filter, status message shows "Filter applied. Press c to clear"

--- a/internal/helpers/filter.go
+++ b/internal/helpers/filter.go
@@ -17,35 +17,17 @@ func ApplyEntryFilters(entries []models.Entry, dateFilter string, tagFilters []s
 	return filtered
 }
 
-// ApplyTodoFilters applies visibility, date, and tag filters to todos in a single call.
+// ApplyTodoFilters applies date and tag filters to todos in a single call.
 // This centralizes the common filtering pattern used throughout the codebase.
 //
-// Design: Visibility filter first (removes done todos if hidden), then date, then tags.
-// Returns the original list if all filters are empty/disabled.
-func ApplyTodoFilters(todos []models.Todo, dateFilter string, tagFilters []string, hideCompleted bool) []models.Todo {
-	// Apply visibility filter first (hide completed if enabled)
-	filtered := FilterTodosByVisibility(todos, hideCompleted)
-
+// Design: Date filter first, then tags.
+// Returns the original list if all filters are empty.
+func ApplyTodoFilters(todos []models.Todo, dateFilter string, tagFilters []string) []models.Todo {
 	// Apply date filter
-	filtered = FilterTodosByDateRange(filtered, dateFilter)
+	filtered := FilterTodosByDateRange(todos, dateFilter)
 
 	// Apply tag filter to date-filtered results
 	filtered = FilterTodosByTags(filtered, tagFilters)
 
-	return filtered
-}
-
-// FilterTodosByVisibility filters out done todos if hideCompleted is true.
-// Returns the original slice if hideCompleted is false.
-func FilterTodosByVisibility(todos []models.Todo, hideCompleted bool) []models.Todo {
-	if !hideCompleted {
-		return todos
-	}
-	filtered := make([]models.Todo, 0, len(todos))
-	for _, todo := range todos {
-		if todo.Status != "done" {
-			filtered = append(filtered, todo)
-		}
-	}
 	return filtered
 }

--- a/internal/helpers/todos.go
+++ b/internal/helpers/todos.go
@@ -3,8 +3,10 @@ package helpers
 import (
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/apodacaa/amos/internal/models"
+	"github.com/google/uuid"
 )
 
 // ExtractTodos finds all !todo items in text and returns their titles
@@ -23,17 +25,55 @@ func ExtractTodos(text string) []string {
 	return todos
 }
 
-// RemoveTodoMarkup removes all lines starting with "!todo" from text
-// Returns cleaned text with !todo lines removed
-func RemoveTodoMarkup(text string) string {
-	// Match !todo followed by text until end of line (including the newline)
-	re := regexp.MustCompile(`(?m)^!todo\s+.+$\n?`)
-	cleaned := re.ReplaceAllString(text, "")
+// SyncEntryTodos reconciles the todo list with the current !todo lines in an entry.
+// For each todoTitle, if a todo with matching Title AND EntryID already exists, skip (dedup).
+// If a todoTitle has no match, create a new todo.
+// For each existing todo linked to this entry, if its title does NOT appear in todoTitles, orphan it (set EntryID to nil).
+// Returns the updated full todos slice (ready for batch save).
+func SyncEntryTodos(allTodos []models.Todo, entryID string, todoTitles []string) []models.Todo {
+	// Build set of current !todo titles
+	titleSet := make(map[string]bool, len(todoTitles))
+	for _, title := range todoTitles {
+		titleSet[strings.TrimSpace(title)] = true
+	}
 
-	// Trim excess blank lines (don't leave gaps - max 2 newlines = 1 blank line)
-	cleaned = regexp.MustCompile(`\n{3,}`).ReplaceAllString(cleaned, "\n\n")
+	// Track which titles already have matching todos
+	matched := make(map[string]bool, len(todoTitles))
 
-	return strings.TrimSpace(cleaned)
+	// Iterate existing todos: orphan removed ones, mark matched ones
+	for i := range allTodos {
+		if allTodos[i].EntryID == nil || *allTodos[i].EntryID != entryID {
+			continue
+		}
+		trimmedTitle := strings.TrimSpace(allTodos[i].Title)
+		if titleSet[trimmedTitle] {
+			matched[trimmedTitle] = true
+		} else {
+			// Orphan: title no longer in entry text
+			allTodos[i].EntryID = nil
+		}
+	}
+
+	// Create new todos for unmatched titles
+	for _, title := range todoTitles {
+		trimmed := strings.TrimSpace(title)
+		if !matched[trimmed] {
+			now := time.Now()
+			entryIDCopy := entryID
+			newTodo := models.Todo{
+				ID:        uuid.New().String(),
+				Title:     trimmed,
+				Status:    "open",
+				Tags:      ExtractTags(trimmed),
+				CreatedAt: now,
+				UpdatedAt: now,
+				EntryID:   &entryIDCopy,
+			}
+			allTodos = append(allTodos, newTodo)
+		}
+	}
+
+	return allTodos
 }
 
 // FilterTodosByEntry returns todos that belong to the specified entry

--- a/internal/helpers/todos_test.go
+++ b/internal/helpers/todos_test.go
@@ -55,64 +55,155 @@ func TestExtractTodos(t *testing.T) {
 	}
 }
 
-func TestRemoveTodoMarkup(t *testing.T) {
+func TestSyncEntryTodos(t *testing.T) {
+	entryID := "entry-1"
+	otherEntryID := "entry-2"
+
 	tests := []struct {
-		name     string
-		text     string
-		expected string
+		name           string
+		allTodos       []models.Todo
+		entryID        string
+		todoTitles     []string
+		wantLinked     int // expected todos linked to entryID after sync
+		wantOrphaned   int // expected todos orphaned (EntryID set to nil) from this entry
+		wantTotalNew   int // expected new todos created
+		checkOrphanIDs []string
 	}{
 		{
-			name:     "single todo line",
-			text:     "Some text\n!todo make toast\nMore text",
-			expected: "Some text\nMore text",
+			name:         "new entry with new todos",
+			allTodos:     []models.Todo{},
+			entryID:      entryID,
+			todoTitles:   []string{"Task one", "Task two"},
+			wantLinked:   2,
+			wantTotalNew: 2,
 		},
 		{
-			name:     "multiple todo lines",
-			text:     "!todo first\n!todo second\nRegular text",
-			expected: "Regular text",
+			name: "re-save with same todos (no duplicates)",
+			allTodos: []models.Todo{
+				{ID: "t1", Title: "Task one", Status: "open", EntryID: &entryID},
+				{ID: "t2", Title: "Task two", Status: "next", EntryID: &entryID},
+			},
+			entryID:      entryID,
+			todoTitles:   []string{"Task one", "Task two"},
+			wantLinked:   2,
+			wantTotalNew: 0,
 		},
 		{
-			name:     "no todo lines",
-			text:     "Just regular text\nwith no todos",
-			expected: "Just regular text\nwith no todos",
+			name: "removed todo line orphans existing todo",
+			allTodos: []models.Todo{
+				{ID: "t1", Title: "Task one", Status: "open", EntryID: &entryID},
+				{ID: "t2", Title: "Task two", Status: "done", EntryID: &entryID},
+			},
+			entryID:        entryID,
+			todoTitles:     []string{"Task one"},
+			wantLinked:     1,
+			wantOrphaned:   1,
+			checkOrphanIDs: []string{"t2"},
 		},
 		{
-			name:     "todo with tags",
-			text:     "Notes\n!todo Buy groceries @personal\nEnd",
-			expected: "Notes\nEnd",
+			name: "added todo line creates only the new one",
+			allTodos: []models.Todo{
+				{ID: "t1", Title: "Task one", Status: "open", EntryID: &entryID},
+			},
+			entryID:      entryID,
+			todoTitles:   []string{"Task one", "Task three"},
+			wantLinked:   2,
+			wantTotalNew: 1,
 		},
 		{
-			name:     "todo not at line start (should not be removed)",
-			text:     "Some text !todo inline",
-			expected: "Some text !todo inline",
+			name: "empty todoTitles orphans all linked todos",
+			allTodos: []models.Todo{
+				{ID: "t1", Title: "Task one", Status: "open", EntryID: &entryID},
+				{ID: "t2", Title: "Task two", Status: "next", EntryID: &entryID},
+			},
+			entryID:        entryID,
+			todoTitles:     []string{},
+			wantLinked:     0,
+			wantOrphaned:   2,
+			checkOrphanIDs: []string{"t1", "t2"},
 		},
 		{
-			name:     "multiple spaces after !todo",
-			text:     "!todo     Task with spaces\nText",
-			expected: "Text",
+			name: "same title but different entryID is not deduped",
+			allTodos: []models.Todo{
+				{ID: "t1", Title: "Task one", Status: "open", EntryID: &otherEntryID},
+			},
+			entryID:      entryID,
+			todoTitles:   []string{"Task one"},
+			wantLinked:   1,
+			wantTotalNew: 1,
 		},
 		{
-			name:     "only todo lines",
-			text:     "!todo first\n!todo second",
-			expected: "",
-		},
-		{
-			name:     "todo lines with excess blank lines",
-			text:     "Text\n!todo task\n\n\nMore text",
-			expected: "Text\n\nMore text",
-		},
-		{
-			name:     "mixed content",
-			text:     "Meeting notes\n!todo follow up\nDiscussed features\n!todo review docs\nEnd",
-			expected: "Meeting notes\nDiscussed features\nEnd",
+			name: "orphaned todo preserves status and tags",
+			allTodos: []models.Todo{
+				{ID: "t1", Title: "Task @work", Status: "next", Tags: []string{"work"}, EntryID: &entryID},
+			},
+			entryID:        entryID,
+			todoTitles:     []string{},
+			wantOrphaned:   1,
+			checkOrphanIDs: []string{"t1"},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := RemoveTodoMarkup(tt.text)
-			if got != tt.expected {
-				t.Errorf("RemoveTodoMarkup() = %q, want %q", got, tt.expected)
+			// Deep copy allTodos to avoid mutation across tests
+			input := make([]models.Todo, len(tt.allTodos))
+			for i, todo := range tt.allTodos {
+				input[i] = todo
+				if todo.EntryID != nil {
+					id := *todo.EntryID
+					input[i].EntryID = &id
+				}
+			}
+
+			result := SyncEntryTodos(input, tt.entryID, tt.todoTitles)
+
+			// Count linked todos for this entry
+			linked := 0
+			for _, todo := range result {
+				if todo.EntryID != nil && *todo.EntryID == tt.entryID {
+					linked++
+				}
+			}
+			if linked != tt.wantLinked {
+				t.Errorf("linked todos = %d, want %d", linked, tt.wantLinked)
+			}
+
+			// Check orphaned todos
+			if len(tt.checkOrphanIDs) > 0 {
+				orphaned := 0
+				for _, todo := range result {
+					for _, orphanID := range tt.checkOrphanIDs {
+						if todo.ID == orphanID && todo.EntryID == nil {
+							orphaned++
+						}
+					}
+				}
+				if orphaned != tt.wantOrphaned {
+					t.Errorf("orphaned todos = %d, want %d", orphaned, tt.wantOrphaned)
+				}
+			}
+
+			// Check new todos created
+			if tt.wantTotalNew > 0 {
+				newCount := len(result) - len(tt.allTodos)
+				if newCount != tt.wantTotalNew {
+					t.Errorf("new todos created = %d, want %d", newCount, tt.wantTotalNew)
+				}
+			}
+
+			// Check orphaned todo preserves fields
+			if tt.name == "orphaned todo preserves status and tags" {
+				for _, todo := range result {
+					if todo.ID == "t1" {
+						if todo.Status != "next" {
+							t.Errorf("orphaned todo status = %q, want %q", todo.Status, "next")
+						}
+						if len(todo.Tags) != 1 || todo.Tags[0] != "work" {
+							t.Errorf("orphaned todo tags = %v, want [work]", todo.Tags)
+						}
+					}
+				}
 			}
 		})
 	}

--- a/internal/storage/system_config.go
+++ b/internal/storage/system_config.go
@@ -9,9 +9,8 @@ import (
 // SystemConfig stores all application settings
 // Stored in ~/.config/amos/settings.json
 type SystemConfig struct {
-	DataDir            string `json:"data_dir,omitempty"`             // Custom data directory path
-	Theme              string `json:"theme,omitempty"`                // Theme name (e.g., "cyberpunk", "brutalist")
-	HideCompletedTodos bool   `json:"hide_completed_todos,omitempty"` // Hide done todos in todo list
+	DataDir string `json:"data_dir,omitempty"` // Custom data directory path
+	Theme   string `json:"theme,omitempty"`    // Theme name (e.g., "cyberpunk", "brutalist")
 }
 
 // DefaultSystemConfig returns the default configuration

--- a/model.go
+++ b/model.go
@@ -262,18 +262,15 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Parse title and body from content
 		title, body := helpers.ParseEntryContent(content)
 
-		// Extract todos from content BEFORE cleaning
-		todoTitles := helpers.ExtractTodos(content)
+		// Extract todos from body
+		todoTitles := helpers.ExtractTodos(body)
 
-		// Remove !todo markup from body
-		cleanedBody := helpers.RemoveTodoMarkup(body)
+		// Extract tags from title and body (includes tags from !todo lines)
+		tags := helpers.ExtractTags(title + " " + body)
 
-		// Extract tags from title and cleaned body
-		tags := helpers.ExtractTags(title + " " + cleanedBody)
-
-		// Update entry
+		// Update entry (body preserved with !todo lines intact)
 		m.currentEntry.Title = title
-		m.currentEntry.Body = cleanedBody
+		m.currentEntry.Body = body
 		m.currentEntry.Tags = tags
 		m.currentEntry.UpdatedAt = time.Now()
 
@@ -284,23 +281,18 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, clearStatusAfterDelay()
 		}
 
-		// Create todos from extracted !todo lines
-		for _, todoTitle := range todoTitles {
-			now := time.Now()
-			todo := models.Todo{
-				ID:        uuid.New().String(),
-				Title:     todoTitle,
-				Status:    "open",
-				Tags:      helpers.ExtractTags(todoTitle),
-				CreatedAt: now,
-				UpdatedAt: now,
-				EntryID:   &m.currentEntry.ID,
-			}
-			if err := storage.SaveTodo(todo); err != nil {
-				m.statusMsg = "Error saving todo: " + err.Error()
-				m.statusTime = time.Now()
-				return m, clearStatusAfterDelay()
-			}
+		// Sync todos: dedup existing, orphan removed, create new
+		allTodos, err := storage.LoadTodos()
+		if err != nil {
+			m.statusMsg = "Error loading todos: " + err.Error()
+			m.statusTime = time.Now()
+			return m, clearStatusAfterDelay()
+		}
+		allTodos = helpers.SyncEntryTodos(allTodos, m.currentEntry.ID, todoTitles)
+		if err := storage.SaveTodos(allTodos); err != nil {
+			m.statusMsg = "Error saving todos: " + err.Error()
+			m.statusTime = time.Now()
+			return m, clearStatusAfterDelay()
 		}
 
 		// Update viewingEntry for view_entry
@@ -448,10 +440,10 @@ func (m Model) View() string {
 		sorted := helpers.SortEntriesForDisplay(filtered)
 		return ui.RenderEntryView(m.width, m.height, m.currentTheme, m.viewingEntry, m.todos, m.scrollOffset, m.markedForDeletion, m.statusMsg, m.selectedEntry, len(sorted), m.updateAvailable, m.updateDismissed, m.latestVersion)
 	case "todos":
-		return ui.RenderTodoList(m.width, m.height, m.currentTheme, m.displayTodos, m.entries, m.selectedTodo, m.filterTags, m.filterDate, m.markedForDeletion, m.statusMsg, m.updateAvailable, m.updateDismissed, m.latestVersion, m.sysConfig.HideCompletedTodos)
+		return ui.RenderTodoList(m.width, m.height, m.currentTheme, m.displayTodos, m.entries, m.selectedTodo, m.filterTags, m.filterDate, m.markedForDeletion, m.statusMsg, m.updateAvailable, m.updateDismissed, m.latestVersion)
 	case "view_todo":
 		// Calculate filtered/sorted todo position for footer display
-		filtered := helpers.ApplyTodoFilters(m.displayTodos, m.filterDate, m.filterTags, m.sysConfig.HideCompletedTodos)
+		filtered := helpers.ApplyTodoFilters(m.displayTodos, m.filterDate, m.filterTags)
 		sorted := helpers.SortTodosForDisplay(filtered)
 		return ui.RenderTodoView(m.width, m.height, m.currentTheme, m.viewingTodo, m.entries, m.scrollOffset, m.markedForDeletion, m.statusMsg, m.selectedTodo, len(sorted), m.updateAvailable, m.updateDismissed, m.latestVersion)
 	case "unified_filter":

--- a/ui/entry_list.go
+++ b/ui/entry_list.go
@@ -93,7 +93,7 @@ func RenderEntryList(width, height int, theme Theme, entries []models.Entry, sel
 	list := strings.Join(listItems, "\n")
 
 	// Header
-	header := RenderHeader(width, theme, "n", "new", "a", "todo", "j/k", "nav", "enter", "view", "d", "del", "/", "filter", "t", "todos", "s", "theme", "?", "help", "q", "quit")
+	header := RenderHeader(width, theme, "n", "new", "a", "todo", "j/k", "nav", "enter", "view", "d", "delete", "/", "filter", "t", "todos", "s", "theme", "?", "help", "q", "quit")
 
 	// Footer (show only filter context, no view label)
 	var footerTitle string

--- a/ui/entry_view.go
+++ b/ui/entry_view.go
@@ -134,7 +134,7 @@ func RenderEntryView(width, height int, theme Theme, entry models.Entry, allTodo
 	}
 
 	// Header
-	header := RenderHeader(width, theme, "n", "new", "a", "todo", "i", "edit", "j/k", "nav", "f/b", "page", "d", "del", "e", "entries", "t", "todos", "s", "theme", "?", "help", "q", "quit")
+	header := RenderHeader(width, theme, "n", "new", "a", "todo", "i", "edit", "j/k", "nav", "f/b", "page", "d", "delete", "e", "entries", "t", "todos", "s", "theme", "?", "help", "q", "quit")
 
 	// Footer: entry position + marked indicator + scroll info
 	footerTitle := fmt.Sprintf("Entry %d of %d", currentIndex+1, totalCount)

--- a/ui/todo_list.go
+++ b/ui/todo_list.go
@@ -9,9 +9,9 @@ import (
 )
 
 // RenderTodoList renders the todo list view
-func RenderTodoList(width, height int, theme Theme, todos []models.Todo, entries []models.Entry, selectedIdx int, filterTags []string, filterDate string, markedForDeletion map[string]string, statusMsg string, updateAvailable bool, updateDismissed bool, latestVersion string, hideCompleted bool) string {
-	// Apply filters: visibility, date, then tags
-	filtered := helpers.ApplyTodoFilters(todos, filterDate, filterTags, hideCompleted)
+func RenderTodoList(width, height int, theme Theme, todos []models.Todo, entries []models.Entry, selectedIdx int, filterTags []string, filterDate string, markedForDeletion map[string]string, statusMsg string, updateAvailable bool, updateDismissed bool, latestVersion string) string {
+	// Apply filters: date, then tags
+	filtered := helpers.ApplyTodoFilters(todos, filterDate, filterTags)
 
 	// Build todo list
 	var listItems []string
@@ -138,7 +138,7 @@ func RenderTodoList(width, height int, theme Theme, todos []models.Todo, entries
 	list := strings.Join(listItems, "\n")
 
 	// Header
-	header := RenderHeader(width, theme, "n", "new", "a", "todo", "enter", "view", "j/k", "nav", "o/p/x", "status", "d", "del", "/", "filter", "z", "toggle", "e", "entries", "s", "theme", "?", "help", "q", "quit")
+	header := RenderHeader(width, theme, "n", "new", "a", "todo", "enter", "view", "j/k", "nav", "o/p/x", "status", "d", "delete", "/", "filter", "e", "entries", "s", "theme", "?", "help", "q", "quit")
 
 	// Footer (show only filter context, no view label)
 	var footerTitle string

--- a/ui/todo_view.go
+++ b/ui/todo_view.go
@@ -141,7 +141,7 @@ func RenderTodoView(width, height int, theme Theme, todo models.Todo, allEntries
 	}
 
 	// Header
-	header := RenderHeader(width, theme, "n", "new", "a", "todo", "i", "edit", "o/p/x", "status", "j/k", "nav", "f/b", "page", "d", "del", "e", "entries", "t", "todos", "?", "help", "q", "quit")
+	header := RenderHeader(width, theme, "n", "new", "a", "todo", "i", "edit", "o/p/x", "status", "j/k", "nav", "f/b", "page", "d", "delete", "e", "entries", "t", "todos", "?", "help", "q", "quit")
 
 	// Footer: position + marked indicator + scroll info
 	footerTitle := fmt.Sprintf("Todo %d of %d", currentIndex+1, totalCount)

--- a/update_todos.go
+++ b/update_todos.go
@@ -73,20 +73,9 @@ func (m Model) handleTodosListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "c":
 		// Clear all filters
 		return m.clearFilters()
-	case "z":
-		// Toggle visibility of completed todos
-		m.sysConfig.HideCompletedTodos = !m.sysConfig.HideCompletedTodos
-		if m.sysConfig.HideCompletedTodos {
-			m.statusMsg = "Completed todos hidden"
-		} else {
-			m.statusMsg = "Showing all todos"
-		}
-		m.statusTime = time.Now()
-		m.selectedTodo = 0 // Reset selection to avoid out-of-bounds
-		return m, tea.Batch(saveConfigCmd(m.sysConfig), clearStatusAfterDelay())
 	case "j", "down":
 		// Apply filters to get the displayed list (same as UI)
-		filtered := helpers.ApplyTodoFilters(m.displayTodos, m.filterDate, m.filterTags, m.sysConfig.HideCompletedTodos)
+		filtered := helpers.ApplyTodoFilters(m.displayTodos, m.filterDate, m.filterTags)
 
 		if m.selectedTodo < len(filtered)-1 {
 			m.selectedTodo++
@@ -99,7 +88,7 @@ func (m Model) handleTodosListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	case "d":
 		// Toggle mark for deletion
-		filtered := helpers.ApplyTodoFilters(m.displayTodos, m.filterDate, m.filterTags, m.sysConfig.HideCompletedTodos)
+		filtered := helpers.ApplyTodoFilters(m.displayTodos, m.filterDate, m.filterTags)
 
 		if m.selectedTodo >= 0 && m.selectedTodo < len(filtered) {
 			selectedTodo := filtered[m.selectedTodo]
@@ -204,7 +193,7 @@ func (m Model) handleTodosListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 		// Open selected todo for read-only viewing
 		// Apply filters (same logic as UI)
-		filtered := helpers.ApplyTodoFilters(m.displayTodos, m.filterDate, m.filterTags, m.sysConfig.HideCompletedTodos)
+		filtered := helpers.ApplyTodoFilters(m.displayTodos, m.filterDate, m.filterTags)
 
 		if m.selectedTodo >= 0 && m.selectedTodo < len(filtered) {
 			m.viewingTodo = filtered[m.selectedTodo]
@@ -221,7 +210,7 @@ func (m Model) handleTodosListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 // setTodoStatus sets the status of the selected todo and saves immediately
 func (m Model) setTodoStatus(status string, statusMsg string) (tea.Model, tea.Cmd) {
 	// Apply filters to get the displayed list
-	filtered := helpers.ApplyTodoFilters(m.displayTodos, m.filterDate, m.filterTags, m.sysConfig.HideCompletedTodos)
+	filtered := helpers.ApplyTodoFilters(m.displayTodos, m.filterDate, m.filterTags)
 
 	if m.selectedTodo >= 0 && m.selectedTodo < len(filtered) {
 		todo := filtered[m.selectedTodo]

--- a/update_view_todo.go
+++ b/update_view_todo.go
@@ -85,7 +85,7 @@ func (m Model) handleViewTodoKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "j", "down":
 		// Navigate to next todo (open → next → done order)
 		// Apply filters and sort (same as todo list view)
-		filtered := helpers.ApplyTodoFilters(m.displayTodos, m.filterDate, m.filterTags, m.sysConfig.HideCompletedTodos)
+		filtered := helpers.ApplyTodoFilters(m.displayTodos, m.filterDate, m.filterTags)
 
 		if len(filtered) > 0 {
 			// Find current todo index in filtered list
@@ -108,7 +108,7 @@ func (m Model) handleViewTodoKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "k", "up":
 		// Navigate to previous todo (open → next → done order)
 		// Apply filters and sort (same as todo list view)
-		filtered := helpers.ApplyTodoFilters(m.displayTodos, m.filterDate, m.filterTags, m.sysConfig.HideCompletedTodos)
+		filtered := helpers.ApplyTodoFilters(m.displayTodos, m.filterDate, m.filterTags)
 
 		if len(filtered) > 0 {
 			// Find current todo index in filtered list


### PR DESCRIPTION
- Replace RemoveTodoMarkup with SyncEntryTodos: dedup by title+entryID, orphan todos whose !todo lines are removed from entry
- Remove hide completed todos feature (z key, HideCompletedTodos config, FilterTodosByVisibility)
- Rename header key label "del" to "delete" across all views