### PR TITLE
Add update todo and done CLI commands; bump to 1.8.1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,12 +28,15 @@ Amos supports headless CLI commands for scripting and agent integration. All out
 | `amos add todo --title T [--status S]` | Create a standalone todo (status: open\|next\|done, default: open) |
 | `amos list entries [--tag TAG]` | List entries as JSON (optional tag filter) |
 | `amos list todos [--tag TAG] [--status S]` | List todos as JSON (optional tag/status filter) |
+| `amos update todo <id> --status S` | Update an existing todo's status by id (open\|next\|done, refreshes updated_at) |
+| `amos done <id>` | Mark a todo done (alias for `update todo <id> --status done`, idempotent) |
 | `amos --help` | Show usage information |
 
 - On success, prints created/listed item(s) as JSON to stdout
 - On error, prints `{"error": "..."}` to stderr and exits with code 1
 - Tags are auto-extracted from `@mention` syntax in title and body
 - `!todo` lines in entry body create linked todos via SyncEntryTodos
+- `update todo` / `done` take the same UUID `list todos` emits in `id`; unknown id exits 1, re-completing an already-done todo exits 0
 
 **Important**: Always run `make ci` before committing. The git pre-commit hook (installed via `./scripts/install-hooks.sh`) runs this automatically.
 
@@ -154,7 +157,7 @@ The codebase uses domain-based separation for maintainability:
 ```
 main.go                  # Entry point + CLI routing (~80 lines)
 cli/
-  cli.go                 # CLI subcommands (add, list) - headless JSON interface
+  cli.go                 # CLI subcommands (add, list, update, done) - headless JSON interface
 model.go                 # Model struct + Init/Update/View (Elm core)
 messages.go              # All message types (saveCompleteMsg, entriesLoadedMsg, etc.)
 commands.go              # All tea.Cmd functions (side effects: save, load, launchEditor, etc.)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,8 @@ Amos is a minimal Bubble Tea (Go) TUI for journal + todo management with a bruta
 | `make build` | Build binary to `./amos` |
 | `make install-air` | Install air for hot reload (then run `air`) |
 
+**Important — install policy**: Homebrew is the ONLY install channel. Never copy a locally built `./amos` over the Homebrew binary (e.g. into `/opt/homebrew/Cellar/...` or anywhere on PATH). Local builds are for running tests and verifying behavior in the working directory only. To ship a change to the installed binary, follow RELEASE.md (version bump, tag, GitHub release, update `homebrew-amos` formula), then `brew upgrade amos`.
+
 ## CLI Commands
 
 Amos supports headless CLI commands for scripting and agent integration. All output is JSON.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,23 @@ Amos is a minimal Bubble Tea (Go) TUI for journal + todo management with a bruta
 | `make build` | Build binary to `./amos` |
 | `make install-air` | Install air for hot reload (then run `air`) |
 
+## CLI Commands
+
+Amos supports headless CLI commands for scripting and agent integration. All output is JSON.
+
+| Command | Description |
+|---------|-------------|
+| `amos add entry --title T [--body B]` | Create a journal entry (extracts tags, syncs `!todo` lines) |
+| `amos add todo --title T [--status S]` | Create a standalone todo (status: open\|next\|done, default: open) |
+| `amos list entries [--tag TAG]` | List entries as JSON (optional tag filter) |
+| `amos list todos [--tag TAG] [--status S]` | List todos as JSON (optional tag/status filter) |
+| `amos --help` | Show usage information |
+
+- On success, prints created/listed item(s) as JSON to stdout
+- On error, prints `{"error": "..."}` to stderr and exits with code 1
+- Tags are auto-extracted from `@mention` syntax in title and body
+- `!todo` lines in entry body create linked todos via SyncEntryTodos
+
 **Important**: Always run `make ci` before committing. The git pre-commit hook (installed via `./scripts/install-hooks.sh`) runs this automatically.
 
 **Important**: After committing, update CLAUDE.md if the change affects architecture, config fields, or user-facing behavior.
@@ -135,7 +152,9 @@ The app follows Bubble Tea's Elm architecture pattern:
 The codebase uses domain-based separation for maintainability:
 
 ```
-main.go                  # Entry point only (~10 lines)
+main.go                  # Entry point + CLI routing (~80 lines)
+cli/
+  cli.go                 # CLI subcommands (add, list) - headless JSON interface
 model.go                 # Model struct + Init/Update/View (Elm core)
 messages.go              # All message types (saveCompleteMsg, entriesLoadedMsg, etc.)
 commands.go              # All tea.Cmd functions (side effects: save, load, launchEditor, etc.)

--- a/Makefile
+++ b/Makefile
@@ -7,24 +7,24 @@ help: ## Show this help message
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2}'
 
 build: ## Build the binary
-	go build -ldflags "-X main.Version=1.7.3" -o amos
+	go build -ldflags "-X main.Version=1.8.0" -o amos
 
 build-windows: ## Build Windows binary (amd64)
-	GOOS=windows GOARCH=amd64 go build -ldflags "-X main.Version=1.7.3" -o amos.exe
+	GOOS=windows GOARCH=amd64 go build -ldflags "-X main.Version=1.8.0" -o amos.exe
 
 build-all: ## Build binaries for all platforms
 	@echo "Building for Linux (amd64)..."
-	GOOS=linux GOARCH=amd64 go build -ldflags "-X main.Version=1.7.3" -o amos-linux-amd64
+	GOOS=linux GOARCH=amd64 go build -ldflags "-X main.Version=1.8.0" -o amos-linux-amd64
 	@echo "Building for macOS (amd64)..."
-	GOOS=darwin GOARCH=amd64 go build -ldflags "-X main.Version=1.7.3" -o amos-darwin-amd64
+	GOOS=darwin GOARCH=amd64 go build -ldflags "-X main.Version=1.8.0" -o amos-darwin-amd64
 	@echo "Building for macOS (arm64)..."
-	GOOS=darwin GOARCH=arm64 go build -ldflags "-X main.Version=1.7.3" -o amos-darwin-arm64
+	GOOS=darwin GOARCH=arm64 go build -ldflags "-X main.Version=1.8.0" -o amos-darwin-arm64
 	@echo "Building for Windows (amd64)..."
-	GOOS=windows GOARCH=amd64 go build -ldflags "-X main.Version=1.7.3" -o amos-windows-amd64.exe
+	GOOS=windows GOARCH=amd64 go build -ldflags "-X main.Version=1.8.0" -o amos-windows-amd64.exe
 	@echo "✓ All binaries built"
 
 run: ## Run the app
-	go build -ldflags "-X main.Version=1.7.3" -o amos && ./amos
+	go build -ldflags "-X main.Version=1.8.0" -o amos && ./amos
 
 fmt: ## Format code
 	go fmt ./...
@@ -84,7 +84,7 @@ gen-test-data: ## Generate test data (usage: make gen-test-data ENTRIES=1000 TOD
 release: ## Create a new release (usage: make release VERSION=1.2.1 [NOTES=release-notes.md] [DRY_RUN=true])
 	@if [ -z "$(VERSION)" ]; then \
 		echo "Error: VERSION required"; \
-		echo "Usage: make release VERSION=1.7.3 [NOTES=release-notes.md] [DRY_RUN=true]"; \
+		echo "Usage: make release VERSION=1.8.0 [NOTES=release-notes.md] [DRY_RUN=true]"; \
 		exit 1; \
 	fi
 	@./scripts/release.sh $(VERSION) "$(NOTES)" "$(DRY_RUN)"

--- a/Makefile
+++ b/Makefile
@@ -7,24 +7,24 @@ help: ## Show this help message
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2}'
 
 build: ## Build the binary
-	go build -ldflags "-X main.Version=1.8.0" -o amos
+	go build -ldflags "-X main.Version=1.8.1" -o amos
 
 build-windows: ## Build Windows binary (amd64)
-	GOOS=windows GOARCH=amd64 go build -ldflags "-X main.Version=1.8.0" -o amos.exe
+	GOOS=windows GOARCH=amd64 go build -ldflags "-X main.Version=1.8.1" -o amos.exe
 
 build-all: ## Build binaries for all platforms
 	@echo "Building for Linux (amd64)..."
-	GOOS=linux GOARCH=amd64 go build -ldflags "-X main.Version=1.8.0" -o amos-linux-amd64
+	GOOS=linux GOARCH=amd64 go build -ldflags "-X main.Version=1.8.1" -o amos-linux-amd64
 	@echo "Building for macOS (amd64)..."
-	GOOS=darwin GOARCH=amd64 go build -ldflags "-X main.Version=1.8.0" -o amos-darwin-amd64
+	GOOS=darwin GOARCH=amd64 go build -ldflags "-X main.Version=1.8.1" -o amos-darwin-amd64
 	@echo "Building for macOS (arm64)..."
-	GOOS=darwin GOARCH=arm64 go build -ldflags "-X main.Version=1.8.0" -o amos-darwin-arm64
+	GOOS=darwin GOARCH=arm64 go build -ldflags "-X main.Version=1.8.1" -o amos-darwin-arm64
 	@echo "Building for Windows (amd64)..."
-	GOOS=windows GOARCH=amd64 go build -ldflags "-X main.Version=1.8.0" -o amos-windows-amd64.exe
+	GOOS=windows GOARCH=amd64 go build -ldflags "-X main.Version=1.8.1" -o amos-windows-amd64.exe
 	@echo "✓ All binaries built"
 
 run: ## Run the app
-	go build -ldflags "-X main.Version=1.8.0" -o amos && ./amos
+	go build -ldflags "-X main.Version=1.8.1" -o amos && ./amos
 
 fmt: ## Format code
 	go fmt ./...

--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ amos list entries
 # List todos filtered by tag and status
 amos list todos --tag work --status open
 
+# Update an existing todo's status by id (the id field from list todos)
+amos update todo <id> --status next
+
+# Mark a todo done (alias for update todo <id> --status done)
+amos done <id>
+
 # Help
 amos --help
 ```
@@ -255,7 +261,7 @@ air               # Run with auto-reload
 .
 ├── main.go                 # Entry point + CLI routing
 ├── cli/
-│   └── cli.go              # CLI subcommands (add, list) - JSON interface
+│   └── cli.go              # CLI subcommands (add, list, update, done) - JSON interface
 ├── model.go                # Model, Init, Update, View (Elm architecture)
 ├── messages.go             # Message types for async operations
 ├── commands.go             # tea.Cmd functions (side effects)

--- a/README.md
+++ b/README.md
@@ -37,6 +37,34 @@ Run the app:
 amos
 ```
 
+## CLI
+
+Amos supports headless CLI commands for scripting and agent integration. All output is JSON.
+
+```bash
+# Add a journal entry
+amos add entry --title "Deploy prep @work" --body "Check staging environment"
+
+# Add a todo
+amos add todo --title "Review PR @work" --status next
+
+# List all entries
+amos list entries
+
+# List todos filtered by tag and status
+amos list todos --tag work --status open
+
+# Help
+amos --help
+```
+
+Entries support `!todo` syntax in the body — linked todos are created automatically:
+
+```bash
+amos add entry --title "Sprint planning @work" --body '!todo Update backlog @work
+!todo Schedule retro'
+```
+
 **Keyboard Shortcuts:**
 
 *Entry Form:*
@@ -225,7 +253,9 @@ air               # Run with auto-reload
 
 ```
 .
-├── main.go                 # Entry point (~10 lines)
+├── main.go                 # Entry point + CLI routing
+├── cli/
+│   └── cli.go              # CLI subcommands (add, list) - JSON interface
 ├── model.go                # Model, Init, Update, View (Elm architecture)
 ├── messages.go             # Message types for async operations
 ├── commands.go             # tea.Cmd functions (side effects)

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -25,6 +25,10 @@ func Run(args []string) bool {
 		return runAdd(args[2:])
 	case "list":
 		return runList(args[2:])
+	case "update":
+		return runUpdate(args[2:])
+	case "done":
+		return runDone(args[2:])
 	default:
 		return false
 	}
@@ -138,6 +142,95 @@ func addTodo(args []string) bool {
 
 	printJSON(todo)
 	return true
+}
+
+func runUpdate(args []string) bool {
+	if len(args) == 0 {
+		exitError("usage: amos update todo <id> --status <open|next|done>")
+		return true
+	}
+
+	switch args[0] {
+	case "todo":
+		return updateTodo(args[1:])
+	default:
+		exitError("unknown update target: %s (expected todo)", args[0])
+		return true
+	}
+}
+
+func updateTodo(args []string) bool {
+	if len(args) == 0 || strings.HasPrefix(args[0], "-") {
+		exitError("usage: amos update todo <id> --status <open|next|done>")
+		return true
+	}
+
+	id := args[0]
+
+	fs := flag.NewFlagSet("update todo", flag.ContinueOnError)
+	status := fs.String("status", "", "todo status (open, next, done)")
+
+	if err := fs.Parse(args[1:]); err != nil {
+		exitError("invalid flags: %v", err)
+		return true
+	}
+
+	if *status == "" {
+		exitError("--status is required")
+		return true
+	}
+
+	if *status != "open" && *status != "next" && *status != "done" {
+		exitError("invalid status: %s (expected open, next, or done)", *status)
+		return true
+	}
+
+	todo, err := updateTodoStatus(id, *status)
+	if err != nil {
+		exitError("%v", err)
+		return true
+	}
+
+	printJSON(todo)
+	return true
+}
+
+func runDone(args []string) bool {
+	if len(args) != 1 || strings.HasPrefix(args[0], "-") {
+		exitError("usage: amos done <id>")
+		return true
+	}
+
+	todo, err := updateTodoStatus(args[0], "done")
+	if err != nil {
+		exitError("%v", err)
+		return true
+	}
+
+	printJSON(todo)
+	return true
+}
+
+// updateTodoStatus sets the status of an existing todo by ID and refreshes
+// UpdatedAt. Idempotent: setting a status the todo already has succeeds.
+func updateTodoStatus(id, status string) (models.Todo, error) {
+	todos, err := storage.LoadTodos()
+	if err != nil {
+		return models.Todo{}, fmt.Errorf("failed to load todos: %w", err)
+	}
+
+	for i := range todos {
+		if todos[i].ID == id {
+			todos[i].Status = status
+			todos[i].UpdatedAt = time.Now()
+			if err := storage.SaveTodos(todos); err != nil {
+				return models.Todo{}, fmt.Errorf("failed to save todos: %w", err)
+			}
+			return todos[i], nil
+		}
+	}
+
+	return models.Todo{}, fmt.Errorf("todo not found: %s", id)
 }
 
 func runList(args []string) bool {

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -1,0 +1,255 @@
+package cli
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/apodacaa/amos/internal/helpers"
+	"github.com/apodacaa/amos/internal/models"
+	"github.com/apodacaa/amos/internal/storage"
+	"github.com/google/uuid"
+)
+
+// Run handles CLI subcommands. Returns true if a CLI command was handled.
+func Run(args []string) bool {
+	if len(args) < 2 {
+		return false
+	}
+
+	switch args[1] {
+	case "add":
+		return runAdd(args[2:])
+	case "list":
+		return runList(args[2:])
+	default:
+		return false
+	}
+}
+
+func runAdd(args []string) bool {
+	if len(args) == 0 {
+		exitError("usage: amos add <entry|todo> [flags]")
+		return true
+	}
+
+	switch args[0] {
+	case "entry":
+		return addEntry(args[1:])
+	case "todo":
+		return addTodo(args[1:])
+	default:
+		exitError("unknown add target: %s (expected entry or todo)", args[0])
+		return true
+	}
+}
+
+func addEntry(args []string) bool {
+	fs := flag.NewFlagSet("add entry", flag.ContinueOnError)
+	title := fs.String("title", "", "entry title (required)")
+	body := fs.String("body", "", "entry body")
+
+	if err := fs.Parse(args); err != nil {
+		exitError("invalid flags: %v", err)
+		return true
+	}
+
+	if *title == "" {
+		exitError("--title is required")
+		return true
+	}
+
+	now := time.Now()
+	fullText := *title + "\n" + *body
+	tags := helpers.ExtractTags(fullText)
+
+	entry := models.Entry{
+		ID:        uuid.New().String(),
+		Title:     *title,
+		Body:      *body,
+		Tags:      tags,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+
+	if err := storage.SaveEntry(entry); err != nil {
+		exitError("failed to save entry: %v", err)
+		return true
+	}
+
+	// Sync todos from !todo lines in body
+	todoTitles := helpers.ExtractTodos(*body)
+	if len(todoTitles) > 0 {
+		allTodos, err := storage.LoadTodos()
+		if err != nil {
+			exitError("entry saved but failed to load todos for sync: %v", err)
+			return true
+		}
+		allTodos = helpers.SyncEntryTodos(allTodos, entry.ID, todoTitles)
+		if err := storage.SaveTodos(allTodos); err != nil {
+			exitError("entry saved but failed to sync todos: %v", err)
+			return true
+		}
+	}
+
+	printJSON(entry)
+	return true
+}
+
+func addTodo(args []string) bool {
+	fs := flag.NewFlagSet("add todo", flag.ContinueOnError)
+	title := fs.String("title", "", "todo title (required)")
+	status := fs.String("status", "open", "todo status (open, next, done)")
+
+	if err := fs.Parse(args); err != nil {
+		exitError("invalid flags: %v", err)
+		return true
+	}
+
+	if *title == "" {
+		exitError("--title is required")
+		return true
+	}
+
+	if *status != "open" && *status != "next" && *status != "done" {
+		exitError("invalid status: %s (expected open, next, or done)", *status)
+		return true
+	}
+
+	now := time.Now()
+	tags := helpers.ExtractTags(*title)
+
+	todo := models.Todo{
+		ID:        uuid.New().String(),
+		Title:     *title,
+		Status:    *status,
+		Tags:      tags,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+
+	if err := storage.SaveTodo(todo); err != nil {
+		exitError("failed to save todo: %v", err)
+		return true
+	}
+
+	printJSON(todo)
+	return true
+}
+
+func runList(args []string) bool {
+	if len(args) == 0 {
+		exitError("usage: amos list <entries|todos> [flags]")
+		return true
+	}
+
+	switch args[0] {
+	case "entries":
+		return listEntries(args[1:])
+	case "todos":
+		return listTodos(args[1:])
+	default:
+		exitError("unknown list target: %s (expected entries or todos)", args[0])
+		return true
+	}
+}
+
+func listEntries(args []string) bool {
+	fs := flag.NewFlagSet("list entries", flag.ContinueOnError)
+	tag := fs.String("tag", "", "filter by tag (without @ prefix)")
+
+	if err := fs.Parse(args); err != nil {
+		exitError("invalid flags: %v", err)
+		return true
+	}
+
+	entries, err := storage.LoadEntries()
+	if err != nil {
+		exitError("failed to load entries: %v", err)
+		return true
+	}
+
+	if *tag != "" {
+		tagName := strings.TrimPrefix(*tag, "@")
+		var filtered []models.Entry
+		for _, e := range entries {
+			if hasTag(e.Tags, tagName) {
+				filtered = append(filtered, e)
+			}
+		}
+		entries = filtered
+	}
+
+	printJSON(entries)
+	return true
+}
+
+func listTodos(args []string) bool {
+	fs := flag.NewFlagSet("list todos", flag.ContinueOnError)
+	tag := fs.String("tag", "", "filter by tag (without @ prefix)")
+	status := fs.String("status", "", "filter by status (open, next, done)")
+
+	if err := fs.Parse(args); err != nil {
+		exitError("invalid flags: %v", err)
+		return true
+	}
+
+	todos, err := storage.LoadTodos()
+	if err != nil {
+		exitError("failed to load todos: %v", err)
+		return true
+	}
+
+	if *tag != "" {
+		tagName := strings.TrimPrefix(*tag, "@")
+		var filtered []models.Todo
+		for _, t := range todos {
+			if hasTag(t.Tags, tagName) {
+				filtered = append(filtered, t)
+			}
+		}
+		todos = filtered
+	}
+
+	if *status != "" {
+		var filtered []models.Todo
+		for _, t := range todos {
+			if t.Status == *status {
+				filtered = append(filtered, t)
+			}
+		}
+		todos = filtered
+	}
+
+	printJSON(todos)
+	return true
+}
+
+func hasTag(tags []string, target string) bool {
+	target = strings.ToLower(target)
+	for _, t := range tags {
+		if strings.ToLower(t) == target {
+			return true
+		}
+	}
+	return false
+}
+
+func printJSON(v any) {
+	data, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		exitError("failed to marshal JSON: %v", err)
+		return
+	}
+	fmt.Println(string(data))
+}
+
+func exitError(format string, args ...any) {
+	msg := fmt.Sprintf(format, args...)
+	errJSON, _ := json.Marshal(map[string]string{"error": msg})
+	fmt.Fprintln(os.Stderr, string(errJSON))
+	os.Exit(1)
+}

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -1,0 +1,141 @@
+package cli
+
+import (
+	"testing"
+	"time"
+
+	"github.com/apodacaa/amos/internal/models"
+	"github.com/apodacaa/amos/internal/storage"
+)
+
+func setupTestDir(t *testing.T) {
+	t.Helper()
+	if err := storage.SetDataDir(t.TempDir()); err != nil {
+		t.Fatalf("failed to set data dir: %v", err)
+	}
+}
+
+func seedTodo(t *testing.T, todo models.Todo) {
+	t.Helper()
+	if err := storage.SaveTodo(todo); err != nil {
+		t.Fatalf("failed to seed todo: %v", err)
+	}
+}
+
+func TestUpdateTodoStatusDone(t *testing.T) {
+	setupTestDir(t)
+
+	created := time.Now().Add(-time.Hour)
+	seedTodo(t, models.Todo{
+		ID:        "todo-1",
+		Title:     "Test todo",
+		Status:    "open",
+		CreatedAt: created,
+		UpdatedAt: created,
+	})
+
+	updated, err := updateTodoStatus("todo-1", "done")
+	if err != nil {
+		t.Fatalf("updateTodoStatus failed: %v", err)
+	}
+
+	if updated.Status != "done" {
+		t.Errorf("expected status done, got %s", updated.Status)
+	}
+	if !updated.UpdatedAt.After(created) {
+		t.Errorf("expected UpdatedAt to be refreshed, got %v", updated.UpdatedAt)
+	}
+
+	// Verify persisted to store
+	todos, err := storage.LoadTodos()
+	if err != nil {
+		t.Fatalf("failed to load todos: %v", err)
+	}
+	if len(todos) != 1 {
+		t.Fatalf("expected 1 todo, got %d", len(todos))
+	}
+	if todos[0].Status != "done" {
+		t.Errorf("expected persisted status done, got %s", todos[0].Status)
+	}
+}
+
+func TestUpdateTodoStatusUnknownID(t *testing.T) {
+	setupTestDir(t)
+
+	seedTodo(t, models.Todo{
+		ID:        "todo-1",
+		Title:     "Test todo",
+		Status:    "open",
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	})
+
+	_, err := updateTodoStatus("nonexistent-id", "done")
+	if err == nil {
+		t.Fatal("expected error for unknown id, got nil")
+	}
+
+	// Store must be untouched
+	todos, err := storage.LoadTodos()
+	if err != nil {
+		t.Fatalf("failed to load todos: %v", err)
+	}
+	if todos[0].Status != "open" {
+		t.Errorf("expected status unchanged (open), got %s", todos[0].Status)
+	}
+}
+
+func TestUpdateTodoStatusIdempotentRedone(t *testing.T) {
+	setupTestDir(t)
+
+	seedTodo(t, models.Todo{
+		ID:        "todo-1",
+		Title:     "Test todo",
+		Status:    "open",
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	})
+
+	if _, err := updateTodoStatus("todo-1", "done"); err != nil {
+		t.Fatalf("first done failed: %v", err)
+	}
+
+	updated, err := updateTodoStatus("todo-1", "done")
+	if err != nil {
+		t.Fatalf("re-done of already-done todo failed: %v", err)
+	}
+	if updated.Status != "done" {
+		t.Errorf("expected status done, got %s", updated.Status)
+	}
+
+	// No duplicates created
+	todos, err := storage.LoadTodos()
+	if err != nil {
+		t.Fatalf("failed to load todos: %v", err)
+	}
+	if len(todos) != 1 {
+		t.Errorf("expected 1 todo after re-done, got %d", len(todos))
+	}
+}
+
+func TestUpdateTodoStatusOtherStatuses(t *testing.T) {
+	setupTestDir(t)
+
+	seedTodo(t, models.Todo{
+		ID:        "todo-1",
+		Title:     "Test todo",
+		Status:    "done",
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	})
+
+	for _, status := range []string{"next", "open", "done"} {
+		updated, err := updateTodoStatus("todo-1", status)
+		if err != nil {
+			t.Fatalf("update to %s failed: %v", status, err)
+		}
+		if updated.Status != status {
+			t.Errorf("expected status %s, got %s", status, updated.Status)
+		}
+	}
+}

--- a/internal/storage/system_config.go
+++ b/internal/storage/system_config.go
@@ -20,11 +20,18 @@ func DefaultSystemConfig() SystemConfig {
 	}
 }
 
-// GetSystemConfigPath returns ~/.config/amos/settings.json
+// GetSystemConfigPath returns the path to amos/settings.json in the user
+// config directory. XDG_CONFIG_HOME takes priority on all platforms —
+// os.UserConfigDir ignores it on macOS, which would send tests that set it
+// to the real config directory.
 func GetSystemConfigPath() (string, error) {
-	configDir, err := os.UserConfigDir() // Returns ~/.config on Unix
-	if err != nil {
-		return "", err
+	configDir := os.Getenv("XDG_CONFIG_HOME")
+	if configDir == "" {
+		var err error
+		configDir, err = os.UserConfigDir() // Returns ~/.config on Unix
+		if err != nil {
+			return "", err
+		}
 	}
 	return filepath.Join(configDir, "amos", "settings.json"), nil
 }

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/apodacaa/amos/cli"
 	"github.com/apodacaa/amos/internal/helpers"
 	"github.com/apodacaa/amos/internal/storage"
 	tea "github.com/charmbracelet/bubbletea"
@@ -13,6 +14,23 @@ import (
 var Version = "dev"
 
 func main() {
+	// Handle --help flag
+	if len(os.Args) > 1 && (os.Args[1] == "--help" || os.Args[1] == "-h" || os.Args[1] == "help") {
+		fmt.Printf("amos %s - journal + todo manager\n\n", Version)
+		fmt.Println("Usage:")
+		fmt.Println("  amos                                    Launch TUI")
+		fmt.Println("  amos add entry --title T [--body B]     Add a journal entry")
+		fmt.Println("  amos add todo --title T [--status S]    Add a todo (status: open|next|done)")
+		fmt.Println("  amos list entries [--tag TAG]            List entries as JSON")
+		fmt.Println("  amos list todos [--tag TAG] [--status S] List todos as JSON")
+		fmt.Println("")
+		fmt.Println("Flags:")
+		fmt.Println("  -v, --version       Print version")
+		fmt.Println("  --check-update      Check for updates")
+		fmt.Println("  -h, --help          Show this help")
+		os.Exit(0)
+	}
+
 	// Handle --version flag
 	if len(os.Args) > 1 && (os.Args[1] == "--version" || os.Args[1] == "-v") {
 		fmt.Printf("amos version %s\n", Version)
@@ -50,10 +68,15 @@ func main() {
 	}
 
 	// Initialize data directory from env var or system config
-	// Must happen before NewModel() which loads data
+	// Must happen before NewModel() or CLI commands which load data
 	if err := storage.InitializeDataDir(); err != nil {
 		fmt.Fprintf(os.Stderr, "Error initializing data directory: %v\n", err)
 		os.Exit(1)
+	}
+
+	// Handle CLI subcommands (add, list)
+	if cli.Run(os.Args) {
+		return
 	}
 
 	m := NewModel()

--- a/main.go
+++ b/main.go
@@ -23,6 +23,8 @@ func main() {
 		fmt.Println("  amos add todo --title T [--status S]    Add a todo (status: open|next|done)")
 		fmt.Println("  amos list entries [--tag TAG]            List entries as JSON")
 		fmt.Println("  amos list todos [--tag TAG] [--status S] List todos as JSON")
+		fmt.Println("  amos update todo <id> --status S        Update a todo's status (open|next|done)")
+		fmt.Println("  amos done <id>                          Mark a todo done (alias for update todo --status done)")
 		fmt.Println("")
 		fmt.Println("Flags:")
 		fmt.Println("  -v, --version       Print version")


### PR DESCRIPTION
## Summary
- New non-interactive CLI commands to change an existing todo's status by id:
  - `amos update todo <id> --status <open|next|done>`
  - `amos done <id>` — thin alias for `--status done`
- Exit 0 on success (prints updated todo JSON), exit 1 with `{"error": ...}` on unknown id or store failure; idempotent re-done; refreshes `updated_at`
- Brings the v1.8.0 CLI commit (`add`/`list`) into main — it was tagged but never merged
- Fix system config tests writing to the real macOS config dir: `GetSystemConfigPath` now honors `XDG_CONFIG_HOME` on all platforms
- Bump version to 1.8.1; document brew-only install policy in CLAUDE.md

## Test plan
- [x] `make ci` green (4 new tests in cli package: done-by-id, unknown id, idempotent re-done, all statuses)
- [x] Headless end-to-end verified: exit codes, JSON output, no TTY required

🤖 Generated with [Claude Code](https://claude.com/claude-code)